### PR TITLE
[SDAO-41] Add CLI to upgrade contract and manage STKR tokens

### DIFF
--- a/stkr-token/app/Main.hs
+++ b/stkr-token/app/Main.hs
@@ -120,3 +120,4 @@ remoteCmdRunner = \case
     tFromAddr <- Tz.resolve' Tz.AddressAlias tFrom
     tToAddr <- Tz.resolve' Tz.AddressAlias tTo
     callViaMultisig (STKR.Transfer (#from .! tFromAddr, #to .! tToAddr, #value .! tVal)) tViaMultisig
+  Freeze msigOptions -> callViaMultisig (STKR.Freeze ()) msigOptions

--- a/stkr-token/app/Options.hs
+++ b/stkr-token/app/Options.hs
@@ -26,10 +26,12 @@ module Options
   , epochOption
 
   , valueOption
+  , amountOption
   ) where
 
 import Prelude
 
+import Data.Word (Word64) -- FIXME!!! derive Read for Mutez in Morley
 import qualified Data.Text as T
 import qualified Data.Set as S
 import qualified Options.Applicative as Opt
@@ -213,4 +215,10 @@ valueOption :: Opt.Parser Natural
 valueOption = Opt.option Opt.auto $
   Opt.long "value" <> Opt.short 'v'
     <> Opt.help "Value to transfer"
+    <> Opt.metavar "INT"
+
+amountOption :: Opt.Parser Word64
+amountOption = Opt.option Opt.auto $
+  Opt.long "amount" <> Opt.short 'a'
+    <> Opt.help "Amount to withdraw"
     <> Opt.metavar "INT"

--- a/stkr-token/app/Options.hs
+++ b/stkr-token/app/Options.hs
@@ -24,6 +24,8 @@ module Options
 
   , proposalIdOption
   , epochOption
+
+  , valueOption
   ) where
 
 import Prelude
@@ -205,4 +207,10 @@ epochOption :: Opt.Parser Natural
 epochOption = Opt.option Opt.auto $
   Opt.long "epoch" <> Opt.short 'e'
     <> Opt.help "Epoch in which a proposal to vote was created"
+    <> Opt.metavar "INT"
+
+valueOption :: Opt.Parser Natural
+valueOption = Opt.option Opt.auto $
+  Opt.long "value" <> Opt.short 'v'
+    <> Opt.help "Value to transfer"
     <> Opt.metavar "INT"

--- a/stkr-token/app/Parser.hs
+++ b/stkr-token/app/Parser.hs
@@ -12,11 +12,14 @@ module Parser
   , GetBalanceOptions (..)
   , GetTotalSupplyOptions (..)
   , TransferOptions (..)
+  , SetSuccessorOptions (..)
+  , WithdrawOptions (..)
   , cmdParser
   ) where
 
 import Prelude
 
+import Data.Word (Word64) -- FIXME!!! Mutez has noe Read intsance, fix Morley!!!
 import Options.Applicative (command, helper, info, progDesc)
 import qualified Options.Applicative as Opt
 
@@ -50,6 +53,8 @@ data RemoteCommand
   | GetTotalSupply GetTotalSupplyOptions
   | Transfer TransferOptions
   | Freeze ViaMultisigOptions
+  | SetSuccessor SetSuccessorOptions
+  | Withdraw WithdrawOptions
 
 data NewCouncilOptions = NewCouncilOptions
   { ncViaMultisig :: ViaMultisigOptions
@@ -61,6 +66,17 @@ data TransferOptions = TransferOptions
   , tFrom :: OrAlias Address
   , tTo :: OrAlias Address
   , tVal :: Natural
+  }
+
+data SetSuccessorOptions = SetSuccessorOptions
+  { ssViaMultisig :: ViaMultisigOptions
+  , ssSucc :: OrAlias Address
+  }
+
+data WithdrawOptions = WithdrawOptions
+  { wViaMultisig :: ViaMultisigOptions
+  , wFrom :: OrAlias Address
+  , wAmount :: Word64
   }
 
 data GetBalanceOptions = GetBalanceOptions
@@ -148,6 +164,8 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
         , getTotalSupplySubprs
         , transferSubprs
         , freezeSubprs
+        , setSuccessorSubprs
+        , withdrawSubprs
         ]
 
     printMsigSubprs = mkCmdPrs "print-multisig" "Print multisig contract" $
@@ -226,3 +244,18 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
 
     freezeSubprs = mkRemoteCmdPrs "freeze" "Freeze the contract" $
       Freeze <$> viaMultisigOptions
+
+    setSuccessorSubprs = mkRemoteCmdPrs "set-successor-stkr" "Set the successor of STKR contract" $
+      SetSuccessor <$>
+        (SetSuccessorOptions
+          <$> viaMultisigOptions
+          <*> addrOrAliasOption "succ"
+        )
+
+    withdrawSubprs = mkRemoteCmdPrs "withdraw" "Withdraw funds from frozen STKR contract" $
+      Withdraw <$>
+        (WithdrawOptions
+          <$> viaMultisigOptions
+          <*> addrOrAliasOption "from"
+          <*> amountOption
+        )

--- a/stkr-token/app/Parser.hs
+++ b/stkr-token/app/Parser.hs
@@ -49,6 +49,7 @@ data RemoteCommand
   | GetBalance GetBalanceOptions
   | GetTotalSupply GetTotalSupplyOptions
   | Transfer TransferOptions
+  | Freeze ViaMultisigOptions
 
 data NewCouncilOptions = NewCouncilOptions
   { ncViaMultisig :: ViaMultisigOptions
@@ -146,6 +147,7 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
         , getBalanceSubprs
         , getTotalSupplySubprs
         , transferSubprs
+        , freezeSubprs
         ]
 
     printMsigSubprs = mkCmdPrs "print-multisig" "Print multisig contract" $
@@ -221,3 +223,6 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
           <*> addrOrAliasOption "to"
           <*> valueOption
         )
+
+    freezeSubprs = mkRemoteCmdPrs "freeze" "Freeze the contract" $
+      Freeze <$> viaMultisigOptions

--- a/stkr-token/app/Parser.hs
+++ b/stkr-token/app/Parser.hs
@@ -9,6 +9,9 @@ module Parser
   , NewCouncilOptions (..)
   , ViaMultisigOptions (..)
   , VoteForProposalOptions (..)
+  , GetBalanceOptions (..)
+  , GetTotalSupplyOptions (..)
+  , TransferOptions (..)
   , cmdParser
   ) where
 
@@ -43,10 +46,31 @@ data RemoteCommand
   | NewProposal NewProposalOptions
   | NewCouncil NewCouncilOptions
   | VoteForProposal VoteForProposalOptions
+  | GetBalance GetBalanceOptions
+  | GetTotalSupply GetTotalSupplyOptions
+  | Transfer TransferOptions
 
 data NewCouncilOptions = NewCouncilOptions
   { ncViaMultisig :: ViaMultisigOptions
   , ncCouncil :: Either (Text, Int) (Set KeyHash)
+  }
+
+data TransferOptions = TransferOptions
+  { tViaMultisig :: ViaMultisigOptions
+  , tFrom :: OrAlias Address
+  , tTo :: OrAlias Address
+  , tVal :: Natural
+  }
+
+data GetBalanceOptions = GetBalanceOptions
+  { gbStkr :: OrAlias Address
+  -- , gbFrom :: OrAlias Address -- use getStorage API ATM
+  , gbWhose :: OrAlias Address
+  }
+
+data GetTotalSupplyOptions = GetTotalSupplyOptions
+  { gtsStkr :: OrAlias Address
+  -- , gtsFrom :: OrAlias Address -- use getStorage API ATM
   }
 
 data VoteForProposalOptions = VoteForProposalOptions
@@ -119,6 +143,9 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
         , newProposalSubprs
         , newCouncilSubprs
         , voteSubprs
+        , getBalanceSubprs
+        , getTotalSupplySubprs
+        , transferSubprs
         ]
 
     printMsigSubprs = mkCmdPrs "print-multisig" "Print multisig contract" $
@@ -170,3 +197,27 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
 
     printStorageSubprs = mkRemoteCmdPrs "print-storage" "Print storage of a contract" $
       PrintStorage <$> addrOrAliasOption "contract"
+
+    getBalanceSubprs = mkRemoteCmdPrs "get-balance-stkr" "Get balance of a STKR token address" $
+      GetBalance <$>
+        (GetBalanceOptions
+          <$> addrOrAliasOption "stkr"
+          -- <*> addrOrAliasOption "from" -- use getStorage API ATM
+          <*> addrOrAliasOption "whose"
+        )
+
+    getTotalSupplySubprs = mkRemoteCmdPrs "get-total-stkr" "Get total supply of STKR" $
+      GetTotalSupply <$>
+        (GetTotalSupplyOptions
+          <$> addrOrAliasOption "stkr"
+          -- <*> addrOrAliasOption "from" -- use getStorage API ATM
+        )
+
+    transferSubprs = mkRemoteCmdPrs "transfer" "Transfer tokens" $
+      Transfer <$>
+        (TransferOptions
+          <$> viaMultisigOptions
+          <*> addrOrAliasOption "from"
+          <*> addrOrAliasOption "to"
+          <*> valueOption
+        )

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -183,13 +183,3 @@ getBalance stkr whose = withGetStorage f "getBalance" stkr
     f STKR.AlmostStorage{..} = do
         balance <- Tz.getElementTextOfBigMapByAddress whose ledger
         putTextLn $ "Balance: " <> balance
-
-{-
--- We have no `callback_ref` defined ATM
-callGetBalance :: Address -> Address -> Address -> TzTest ()
-callGetBalance stkr who whose =
-  Tz.call who stkr
-    $ STKR.PublicEntrypoint
-    . STKR.GetBalance
-    $ mkView (#owner .! whose) callback_ref
--}

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -22,8 +22,6 @@ import Prelude
 import Fmt (Buildable(..), Builder, mapF)
 import Named (arg)
 
--- import Lorentz (mkView)
--- import Util.Named ((.!))
 import Lorentz.Value (toContractRef, Mutez)
 import Lorentz.Constraints (NicePackedValue)
 import Lorentz.Pack (lPackValue)

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -22,7 +22,6 @@ module TzTest
   , getMainChainId
   , getHeadTimestamp
   , getElementTextOfBigMapByAddress
-  , getElementOfBigMapByAddress
 
   , resolve
   , resolve'
@@ -358,30 +357,15 @@ hashAddressToScriptExpression addr =
   T.strip . lineWithPrefix "Script-expression-ID-Hash: " <$>
      exec False ["hash", "data", "\"" <> formatAddress addr <> "\"", "of", "type", "address"]
 
+-- NOTE: We don't try to interpret tezos client output,
+--   we simply present it to the user.
 getElementTextOfBigMapByHash
   :: Text -> Natural -> TzTest Text
 getElementTextOfBigMapByHash thash bigMapId = do
-  -- FIXME??? I haven't tested it (it fails) and don't yet know what the output
-  --   should be prefixed with (if any), so I assume empty prefix ATM.
-  -- FIXME!!! Handle "Error:\n  Did not find service:"
-  T.strip . lineWithPrefix "" <$>
+  T.strip <$>
      exec True ["get", "element", thash, "of", "big", "map", show bigMapId]
-
-getElementOfBigMapByHash
-  :: forall e. Parsable e
-  => Text -> Natural -> TzTest e
-getElementOfBigMapByHash thash bigMapId = do
-  eltext <- getElementTextOfBigMapByHash thash bigMapId
-  either (fail . pretty) pure $
-    parseLorentzValue @e eltext
 
 getElementTextOfBigMapByAddress
   :: Address -> Natural -> TzTest Text
 getElementTextOfBigMapByAddress addr bigMapId =
   hashAddressToScriptExpression addr >>= (`getElementTextOfBigMapByHash` bigMapId)
-
-getElementOfBigMapByAddress
-  :: forall e. Parsable e
-  => Address -> Natural -> TzTest e
-getElementOfBigMapByAddress addr bigMapId =
-  hashAddressToScriptExpression addr >>= (`getElementOfBigMapByHash` bigMapId)

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -356,7 +356,7 @@ getHeadTimestamp = do
 hashAddressToScriptExpression :: Address -> TzTest Text
 hashAddressToScriptExpression addr =
   T.strip . lineWithPrefix "Script-expression-ID-Hash: " <$>
-     exec ["hash", "data", "\"" <> formatAddress addr <> "\"", "of", "type", "address"]
+     exec False ["hash", "data", "\"" <> formatAddress addr <> "\"", "of", "type", "address"]
 
 getElementTextOfBigMapByHash
   :: Text -> Natural -> TzTest Text
@@ -365,7 +365,7 @@ getElementTextOfBigMapByHash thash bigMapId = do
   --   should be prefixed with (if any), so I assume empty prefix ATM.
   -- FIXME!!! Handle "Error:\n  Did not find service:"
   T.strip . lineWithPrefix "" <$>
-     exec ["get", "element", thash, "of", "big", "map", show bigMapId]
+     exec True ["get", "element", thash, "of", "big", "map", show bigMapId]
 
 getElementOfBigMapByHash
   :: forall e. Parsable e

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -266,6 +266,7 @@ getElementTextOfBigMapByHash
 getElementTextOfBigMapByHash thash bigMapId = do
   -- FIXME??? I haven't tested it (it fails) and don't yet know what the output
   --   should be prefixed with (if any), so I assume empty prefix ATM.
+  -- FIXME!!! Handle "Error:\n  Did not find service:"
   T.strip . lineWithPrefix "" <$>
      exec ["get", "element", thash, "of", "big", "map", show bigMapId]
 

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -316,15 +316,12 @@ importSecretKey alias sk = do
   let addrStr = words output ^. ix 3
   either (fail . pretty) pure (parseAddress addrStr)
 
--- FIXME? Move to Morley?
-type Parsable t =
-  ( IsoValue t
-  , SingI (ToT t)
-  , Typeable (ToT t)
-  )
-
 getStorage
-  :: forall st. Parsable st
+  :: forall st.
+  ( IsoValue st
+  , SingI (ToT st)
+  , Typeable (ToT st)
+  )
   => Address -> TzTest st
 getStorage addr = do
   output <- exec False $

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -71,7 +71,7 @@ execWithShell :: [Text] -> (Shell Line -> Shell Line) -> TzTest Text
 execWithShell args shellTransform = do
   Env{..} <- ask
   Turtle.export "TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER" "YES"
-  putTextLn $ "Executing command: " <> T.intercalate " " args
+  -- putTextLn $ "Executing command: " <> T.intercalate " " args
   let outputShell =
         Turtle.inproc envTezosClientCmd
           ([ "-A", envNode


### PR DESCRIPTION
## Description
https://issues.serokell.io/issue/SDAO-41 is mostly implemented with some additions and omissions.

The addition is we added a CLI for `withdraw` (catch up the master), the omissions are that we haven't created CLIs to `getBalance` and `getTotalSupply` entrypoints (which require to originate callback contract(s)), and instead used `getStorage` API to get these data from the contract's storage.

There exist at least one defect in this implementation: we use `get element of big map` tezos-client call which may fail if the big map doesn't contain the key we requested the value of. We simply present the text output of this call to the user as a result of `getBalance` invocation. ATM we don't intend to improve this, since we want to replace it with the proper `getBalance` entrypoint invocation in future.

Another potential problem is that I've used our existing `callViaMultisig` API when working with frozen contract too (I've factored out the common part into `callViaMultisigGeneric`). Since I don't quite understand the details of tezos runtime behaviour, I don't know if this is a correct approach.