### PR TITLE
[SDAO-43] Fix off-by one in required stages in NewCouncil

### DIFF
--- a/stkr-token/src/Lorentz/Contracts/STKR/Governance/Impl.hs
+++ b/stkr-token/src/Lorentz/Contracts/STKR/Governance/Impl.hs
@@ -17,7 +17,7 @@ newCouncil :: GetCurrentStage -> Entrypoint (Set KeyHash) Storage
 newCouncil curStage = do
   dip $ do
     updateStorage curStage
-    dup # checkNotStages [3, 4]
+    dup # checkNotStages [2, 3]
   setField #councilKeys
   nil; pair
 


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

Problem: In the contract code stages are numbered starting from
zero but the stages when NewCouncil was locked were indexed as if
numbering started from one (i.e., 3 and 4).

Solution: Lock NewCouncil on stages 2 and 3 (starting from zero).
Add tests covering this.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/SDAO-)
## Related issue(s)

Resolves https://issues.serokell.io/issue/SDAO-43

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
