### PR TITLE
[SDAO-41] Show balance nicely, more CLIs

### DIFF
--- a/stkr-token/app/Main.hs
+++ b/stkr-token/app/Main.hs
@@ -58,13 +58,7 @@ signViaMultisig
   -> TzTest (Address, (Msig.Parameter, [(L.PublicKey, L.Signature)]))
 signViaMultisig order ViaMultisigOptions {..} = do
   msigAddr <- Tz.resolve' Tz.ContractAlias vmoMsig
-  (msigAddr, ) <$> (Client.signViaMultisig order $ Client.ViaMultisigOptions
-    { vmoMsig = msigAddr
-    , vmoSign =
-        \bytes ->
-        mapM (Tz.resolve' (Tz.PkSigAlias bytes)) vmoMsigSignatures
-    , ..
-    })
+  (msigAddr, ) <$> Client.signViaMultisig order msigAddr vmoMsigSignatures vmoNonce
 
 printPkSigs
   :: Msig.Order
@@ -149,7 +143,6 @@ remoteCmdRunner = \case
     Client.voteForProposal $ Client.VoteForProposalOptions
       { vpFrom = fromAddr
       , vpStkr = stkrAddr
-      , vpSign = \toSignB -> Tz.resolve' (Tz.PkSigAlias toSignB) vpPkSig
       , ..
       }
   Fund FundOptions {..} -> do

--- a/stkr-token/app/Main.hs
+++ b/stkr-token/app/Main.hs
@@ -140,11 +140,18 @@ remoteCmdRunner = \case
   VoteForProposal VoteForProposalOptions {..} -> do
     fromAddr <- Tz.resolve' Tz.AddressAlias vpFrom
     stkrAddr <- Tz.resolve' Tz.ContractAlias vpStkr
-    Client.voteForProposal $ Client.VoteForProposalOptions
-      { vpFrom = fromAddr
-      , vpStkr = stkrAddr
-      , ..
-      }
+    (pk, sig) <- Client.voteForProposal $ Client.VoteForProposalOptions
+                   { vpFrom = fromAddr
+                   , vpStkr = stkrAddr
+                   , ..
+                   }
+    if vpPrintSig
+      then putTextLn $ formatPublicKey pk <> ":" <> formatSignature sig
+      else
+        Tz.call fromAddr stkrAddr
+          $ STKR.PublicEntrypoint
+          . STKR.VoteForProposal
+          $ (#proposalId vpProposalId, #votePk pk, #voteSig sig)
   Fund FundOptions {..} -> do
     fromAddr <- Tz.resolve' Tz.AddressAlias fnFrom
     stkrAddr <- Tz.resolve' Tz.ContractAlias fnStkr

--- a/stkr-token/app/Main.hs
+++ b/stkr-token/app/Main.hs
@@ -14,7 +14,7 @@ import Tezos.Core (unsafeMkMutez)
 import Util.Named ((.!))
 import Tezos.Crypto (hashKey, formatPublicKey, formatSignature)
 import Util.IO (writeFileUtf8)
-import Lorentz.Value (toContractRef)
+import Lorentz.Value (toContractRef, Address)
 
 import TzTest (TzTest)
 import qualified TzTest as Tz
@@ -55,44 +55,35 @@ localCmdRunner = \case
 signViaMultisig
   :: Msig.Order
   -> ViaMultisigOptions
-  -> TzTest (Msig.Parameter, [(L.PublicKey, L.Signature)])
+  -> TzTest (Address, (Msig.Parameter, [(L.PublicKey, L.Signature)]))
 signViaMultisig order ViaMultisigOptions {..} = do
   msigAddr <- Tz.resolve' Tz.ContractAlias vmoMsig
-  Client.signViaMultisig order $ Client.ViaMultisigOptions
+  (msigAddr, ) <$> (Client.signViaMultisig order $ Client.ViaMultisigOptions
     { vmoMsig = msigAddr
     , vmoSign =
         \bytes ->
         mapM (Tz.resolve' (Tz.PkSigAlias bytes)) vmoMsigSignatures
     , ..
-    }
+    })
 
 printPkSigs
   :: Msig.Order
   -> ViaMultisigOptions
   -> TzTest ()
 printPkSigs order vmo = do
-  (_, pkSigs) <- signViaMultisig order vmo
+  (_, (_, pkSigs)) <- signViaMultisig order vmo
   forM_ pkSigs $ \(pk, sig) ->
     putTextLn $ formatPublicKey pk <> ":" <> formatSignature sig
 
-callViaMultisig' ::
-  (L.Address -> Client.ViaMultisigOptions -> TzTest ())
-   -> ViaMultisigOptions -> TzTest ()
-callViaMultisig' f ViaMultisigOptions {..} = do
+callViaMultisig
+  :: Msig.Order
+  -> ViaMultisigOptions
+  -> TzTest ()
+callViaMultisig order vmo@(ViaMultisigOptions {..}) = do
   fromAddr <- maybe (fail "From address not specified")
                     (Tz.resolve' Tz.AddressAlias) vmoFrom
-  msigAddr <- Tz.resolve' Tz.ContractAlias vmoMsig
-  f fromAddr $ Client.ViaMultisigOptions
-    { vmoMsig = msigAddr
-    , vmoSign =
-        \bytes ->
-        mapM (Tz.resolve' (Tz.PkSigAlias bytes)) vmoMsigSignatures
-    , ..
-    }
-
-callViaMultisig
-  :: Msig.Order -> ViaMultisigOptions -> TzTest ()
-callViaMultisig p = callViaMultisig' (flip Client.callViaMultisig p)
+  (msigAddr, (param, _)) <- signViaMultisig order vmo
+  Tz.call fromAddr msigAddr param
 
 handleFrozenMultisig
   :: Bool

--- a/stkr-token/app/Main.hs
+++ b/stkr-token/app/Main.hs
@@ -29,7 +29,7 @@ import Parser
   NewProposalOptions(..), RemoteAction(..), RemoteCommand(..), TzEnvConfig(..),
   ViaMultisigOptions(..), VoteForProposalOptions(..), GetBalanceOptions(..),
   GetTotalSupplyOptions (..), TransferOptions (..), SetSuccessorOptions (..),
-  WithdrawOptions (..), FreezeOptions (..),
+  WithdrawOptions (..), FreezeOptions (..), FundOptions (..),
   RotateMsigKeysOptions (..), cmdParser)
 
 main :: IO ()
@@ -152,6 +152,10 @@ remoteCmdRunner = \case
       , vpSign = \toSignB -> Tz.resolve' (Tz.PkSigAlias toSignB) vpPkSig
       , ..
       }
+  Fund FundOptions {..} -> do
+    fromAddr <- Tz.resolve' Tz.AddressAlias fnFrom
+    stkrAddr <- Tz.resolve' Tz.ContractAlias fnStkr
+    Client.fund stkrAddr fromAddr (encodeUtf8 fnPayload)
   PrintStorage addr_ ->
     Tz.resolve' Tz.ContractAlias addr_ >>=
     STKR.getStorage >>= liftIO . T.putStrLn . pretty

--- a/stkr-token/app/Options.hs
+++ b/stkr-token/app/Options.hs
@@ -30,6 +30,7 @@ module Options
   , valueOption
   , amountOption
   , printSigsOnlyOption
+  , payloadOption
   ) where
 
 import Prelude
@@ -244,3 +245,8 @@ printSigsOnlyOption :: Opt.Parser Bool
 printSigsOnlyOption = Opt.switch $
   Opt.long "print-sigs"
     <> Opt.help "Print signatures only, do not submit data to network"
+
+payloadOption :: String -> Opt.Parser Text
+payloadOption name = Opt.strOption $ mconcat
+  [ Opt.long $ name <> "Payload"
+  , Opt.metavar "PAYLOAD" ]

--- a/stkr-token/app/Parser.hs
+++ b/stkr-token/app/Parser.hs
@@ -10,6 +10,7 @@ module Parser
   , RotateMsigKeysOptions (..)
   , ViaMultisigOptions (..)
   , VoteForProposalOptions (..)
+  , FundOptions (..)
   , GetBalanceOptions (..)
   , GetTotalSupplyOptions (..)
   , TransferOptions (..)
@@ -51,6 +52,7 @@ data RemoteCommand
   | NewProposal NewProposalOptions
   | NewCouncil NewCouncilOptions
   | VoteForProposal VoteForProposalOptions
+  | Fund FundOptions
   | GetBalance GetBalanceOptions
   | GetTotalSupply GetTotalSupplyOptions
   | Transfer TransferOptions
@@ -123,6 +125,12 @@ data VoteForProposalOptions = VoteForProposalOptions
   , vpProposalId :: Natural
   }
 
+data FundOptions = FundOptions
+  { fnStkr :: OrAlias Address
+  , fnFrom :: OrAlias Address
+  , fnPayload :: Text
+  }
+
 data ViaMultisigOptions = ViaMultisigOptions
   { vmoMsig :: OrAlias Address
   , vmoFrom :: Maybe (OrAlias Address)
@@ -187,6 +195,7 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
         , newProposalSubprs
         , newCouncilSubprs
         , voteSubprs
+        , fundSubprs
         , getBalanceSubprs
         , getTotalSupplySubprs
         , transferSubprs
@@ -253,6 +262,14 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
           <*> pkSigOption "member"
           <*> epochOption
           <*> proposalIdOption
+        )
+
+    fundSubprs = mkRemoteCmdPrs "fund" "Fund the contract" $
+      Fund <$>
+        (FundOptions
+          <$> addrOrAliasOption "stkr"
+          <*> addrOrAliasOption "from"
+          <*> payloadOption "payload"
         )
 
     printStorageSubprs = mkRemoteCmdPrs "print-storage" "Print storage of a contract" $

--- a/stkr-token/app/Parser.hs
+++ b/stkr-token/app/Parser.hs
@@ -123,6 +123,7 @@ data VoteForProposalOptions = VoteForProposalOptions
   , vpPkSig :: OrAlias (PublicKey, Signature)
   , vpEpoch :: Natural
   , vpProposalId :: Natural
+  , vpPrintSig :: Bool
   }
 
 data FundOptions = FundOptions
@@ -262,6 +263,7 @@ cmdParser = info (helper <*> cmdImpl) (progDesc exeDesc)
           <*> pkSigOption "member"
           <*> epochOption
           <*> proposalIdOption
+          <*> printSigsOnlyOption
         )
 
     fundSubprs = mkRemoteCmdPrs "fund" "Fund the contract" $

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -11,6 +11,7 @@ module Lorentz.Contracts.Client
   , ViaMultisigOptions (..)
   , VoteForProposalOptions (..)
   , voteForProposal
+  , fund
   , getTotalSupply
   , getBalance
   , mkStkrOpsOrder
@@ -149,6 +150,13 @@ voteForProposal VoteForProposalOptions {..} = do
     $ STKR.PublicEntrypoint
     . STKR.VoteForProposal
     $ (#proposalId vpProposalId, #votePk pk, #voteSig sig)
+
+-- No dedicated parameters types for all APIs below
+
+fund :: Address -> Address -> ByteString -> TzTest ()
+fund stkr from payload =
+  Tz.call from stkr
+    $ STKR.PublicEntrypoint (STKR.Fund payload)
 
 -- We dont' bother with getBalance/getTotalSupply entrypoints ATM, simply use
 --   getStorage primitive, and return necessary values immediately.

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -132,7 +132,7 @@ data VoteForProposalOptions = VoteForProposalOptions
   , vpProposalId :: Natural
   }
 
-voteForProposal :: VoteForProposalOptions -> TzTest ()
+voteForProposal :: VoteForProposalOptions -> TzTest (PublicKey, Signature)
 voteForProposal VoteForProposalOptions {..} = do
   STKR.AlmostStorage{..} <- STKR.getStorage vpStkr
   proposalHash <-
@@ -140,11 +140,7 @@ voteForProposal VoteForProposalOptions {..} = do
     fmap (arg #proposalHash . snd) . safeHead . snd . splitAt (fromIntegral vpProposalId - 1) $ proposals
   let curStage = vpEpoch*4 + 2
   let toSignB = lPackValue $ STKR.CouncilDataToSign proposalHash vpStkr curStage
-  (pk, sig) <- Tz.resolve' (Tz.PkSigAlias toSignB) vpPkSig
-  Tz.call vpFrom vpStkr
-    $ STKR.PublicEntrypoint
-    . STKR.VoteForProposal
-    $ (#proposalId vpProposalId, #votePk pk, #voteSig sig)
+  Tz.resolve' (Tz.PkSigAlias toSignB) vpPkSig
 
 -- No dedicated parameters types for all APIs below
 

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -7,9 +7,8 @@ module Lorentz.Contracts.Client
   , multisignValue
   , signBytes
   , ContractAddresses (..)
-  , ViaMultisigOptions (..)
-  , callViaMultisig
   , signViaMultisig
+  , ViaMultisigOptions (..)
   , VoteForProposalOptions (..)
   , voteForProposal
   , getTotalSupply
@@ -105,6 +104,12 @@ signViaMultisig order ViaMultisigOptions {..} = do
   let param = Msig.Parameter order nonce pkSigs
   pure (param, pkSigs)
 
+data ViaMultisigOptions = ViaMultisigOptions
+  { vmoMsig :: Address
+  , vmoSign :: ByteString -> TzTest [(PublicKey, Signature)]
+  , vmoNonce :: Maybe Natural
+  }
+
 mkStkrFrozenOrder
   :: STKR.PermitOnFrozenParam
   -> Address
@@ -122,18 +127,6 @@ mkStkrOpsOrder stkrParam stkrAddr =
   Msig.mkCallOrderWrap @STKR.Parameter
     (Msig.Unsafe stkrAddr) #cOpsTeamEntrypoint
     (STKR.EnsureOwner stkrParam)
-
-callViaMultisig
-  :: Address -> Msig.Order -> ViaMultisigOptions -> TzTest ()
-callViaMultisig from order vmo = do
-  (param, _) <- signViaMultisig order vmo
-  Tz.call from (vmoMsig vmo) param
-
-data ViaMultisigOptions = ViaMultisigOptions
-  { vmoMsig :: Address
-  , vmoSign :: ByteString -> TzTest [(PublicKey, Signature)]
-  , vmoNonce :: Maybe Natural
-  }
 
 data VoteForProposalOptions = VoteForProposalOptions
   { vpStkr :: Address

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -399,4 +399,4 @@ getElementTextOfBigMapByHash thash bigMapId = do
 getElementTextOfBigMapByAddress
   :: Address -> Natural -> TzTest Text
 getElementTextOfBigMapByAddress =
-   getElementTextOfBigMapByHash . hashAddressToScriptExpression
+  getElementTextOfBigMapByHash . hashAddressToScriptExpression


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description
Sorry, the PR contains several different changes (rest of [SDAO-41](https://issues.serokell.io/issue/SDAO-41) since the previous PR except `MANUAL.md` changes).

### Changes
* Compute script-expression hash of address in Haskell (we need it to query Tezos bigmaps), this saves us one extra tezos-client invocation and make things more robust
* Rework interactive process handling, now we process `stderr` explicitly too (was inherited before), and now we are able to show balance nicely (eating tezos-client error output and analyzing it)
* Add remaining CLIs (some existing code is also slightly simplified and cleaned up)