### PR TITLE
Awson/sdao53 crypto safety

### DIFF
--- a/stkr-token/package.yaml
+++ b/stkr-token/package.yaml
@@ -36,6 +36,8 @@ library:
     - bytestring
     - haskeline
     - cryptonite
+    - memory
+    - utf8-string
     - text
     - process
     - singletons

--- a/stkr-token/src/DecipherTzEncKey.hs
+++ b/stkr-token/src/DecipherTzEncKey.hs
@@ -1,23 +1,27 @@
 {-# LANGUAGE NoRebindableSyntax #-}
 
-module DecipherTzEncKey (DecipherError(..), decipherTzEncKey) where
+module DecipherTzEncKey (DecipherError(..), decipherTzEncKey, ScrubbedView) where
 
 import Prelude
 
 import Data.Text (Text)
-import qualified Data.Text.Encoding as TE (encodeUtf8)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BSU
-import Foreign.Marshal.Alloc (allocaBytes)
-import Foreign.Ptr (plusPtr)
+import qualified Codec.Binary.UTF8.String as UTF8
+import Foreign.Storable (peek, poke)
+import Foreign.Marshal.Array (pokeArray)
+import Foreign.Ptr (castPtr)
 import Foreign.C.String (CString)
+import Foreign.C (CInt(..))
 import Data.Word (Word64)
+
+import qualified Data.ByteArray as B
 
 import Crypto.KDF.PBKDF2 (Parameters(..), fastPBKDF2_SHA512)
 
 import Tezos.Crypto (B58CheckWithPrefixError, decodeBase58CheckWithPrefix)
 
-foreign import ccall unsafe crypto_secretbox_open :: {- mut -} CString -> CString -> Word64 -> CString -> CString -> IO Int
+foreign import ccall unsafe crypto_secretbox_open :: {- mut -} CString -> CString -> Word64 -> CString -> CString -> IO CInt
 
 data DecipherError
   = DeciferB58Error B58CheckWithPrefixError
@@ -25,36 +29,53 @@ data DecipherError
   | DeciferWrongCipher
   deriving stock (Show)
 
-sodiumSecretboxOpen :: BS.ByteString -> BS.ByteString -> BS.ByteString -> IO (Either DecipherError BS.ByteString)
+type ScrubbedView = B.View B.ScrubbedBytes
+
+sodiumSecretboxOpen :: BS.ByteString -> BS.ByteString -> BS.ByteString -> IO (Either DecipherError ScrubbedView)
 sodiumSecretboxOpen c nonce k
-  | BS.length k /= 32 = err DeciferWrongEncryptionKeyLength
-  | otherwise = allocaBytes plen $ \mptr ->
-                  BSU.unsafeUseAsCString padded $ \pptr ->
-                  BSU.unsafeUseAsCString nonce $ \nptr ->
-                  BSU.unsafeUseAsCString k $ \kptr -> do
-                    r <- crypto_secretbox_open mptr pptr (fromIntegral plen) nptr kptr
-                    if r == 0
-                      then Right <$> BSU.unsafePackCStringLen (plusPtr mptr 32, plen - 32)
-                      else err DeciferWrongCipher
+  | BS.length k /= 32 = pure $ Left DeciferWrongEncryptionKeyLength
+  | otherwise = do
+      opened <- B.alloc plen ini
+      -- reuse the first bytes for ret code (see below)
+      r <- B.withByteArray opened (peek @CInt)
+      pure $
+        if r == 0
+          then Right $ B.view opened 32 (plen - 32)
+          else Left DeciferWrongCipher
   where
+    ini mptr = do
+             BSU.unsafeUseAsCString padded $ \pptr ->
+               BSU.unsafeUseAsCString nonce $ \nptr ->
+                 BSU.unsafeUseAsCString k $ \kptr -> do
+                   r <- crypto_secretbox_open mptr pptr (fromIntegral plen) nptr kptr
+                   -- Inelegant, reuse first bytes to put retcode into.
+                   -- ALTERNATIVES:
+                   --   1. use exceptions (exceptions are not particularly good when used for control flow)
+                   --   2. allocate separate buffer for the ret value (overkill)
+                   poke (castPtr mptr) r
     padded = BS.replicate 16 0 `BS.append` c
     plen = BS.length padded
-    err = pure . Left
 
-decryptKeyBytes :: BS.ByteString -> Text -> IO (Either DecipherError BS.ByteString)
+-- We need scrubbed password here, otherwise `fastPBKDF2_SHA512` simply pokes
+--   the string into buffer.
+decryptKeyBytes :: BS.ByteString -> B.ScrubbedBytes -> IO (Either DecipherError ScrubbedView)
 decryptKeyBytes keyBytes password = sodiumSecretboxOpen key nonce encryptionKey
   where
     nonce = BS.replicate 24 0
     (salt, key) = BS.splitAt 8 keyBytes
-    encryptionKey = fastPBKDF2_SHA512 (Parameters 32768 32) (TE.encodeUtf8 password) salt
+    encryptionKey = fastPBKDF2_SHA512 (Parameters 32768 32) password salt
 
 decodeKeyBytes :: Text -> Either B58CheckWithPrefixError BS.ByteString
 decodeKeyBytes = decodeBase58CheckWithPrefix ed25589_enc_prefix
   where
     ed25589_enc_prefix = BS.pack [7, 90, 60, 179, 41]
 
-decipherTzEncKey :: Text -> Text -> IO (Either DecipherError BS.ByteString)
+-- We have the password as a String (list of char), pretend it's safe if not
+--   poked into a non-scrubbable buffer.
+decipherTzEncKey :: Text -> String -> IO (Either DecipherError ScrubbedView)
 decipherTzEncKey t password =
-    case decodeKeyBytes t of
-      Right kb -> decryptKeyBytes kb password
-      Left err -> pure (Left $ DeciferB58Error err)
+  case decodeKeyBytes t of
+    Right kb -> B.alloc (length passutf8) (flip pokeArray passutf8) >>= decryptKeyBytes kb
+    Left err -> pure (Left $ DeciferB58Error err)
+  where
+    passutf8 = UTF8.encode password

--- a/stkr-token/src/TzTest.hs
+++ b/stkr-token/src/TzTest.hs
@@ -236,7 +236,7 @@ lineWithPrefix prefix txt
       mapMaybe (T.stripPrefix prefix) (lines txt)
 
 -- Tezos.Crypto exports SecretKey abstractly, don't bother to change it
-mySignPK :: ByteString -> ByteString -> (PublicKey, Signature)
+mySignPK :: ScrubbedView -> ByteString -> (PublicKey, Signature)
 mySignPK skBytes bytes = (PublicKey pk, Signature . Ed25519.sign sk pk . blake2b $ bytes)
   where
     sk = CE.throwCryptoError $ Ed25519.secretKey skBytes
@@ -249,6 +249,7 @@ generateSigPK alias bytes = do
   if "encrypted:" `T.isPrefixOf` tzsk
     then
       let attempt n = do
+            -- Pretend it's safe to have the password as a list (not buffer)
             mbPass <- liftIO
               $ runInputT defaultSettings (getPassword (Just '*')
               $ "Please, enter the password for " <> toString alias <> ": ")


### PR DESCRIPTION
## Description
Use `ScrubbedBytes` for sensitive data, shall be safe from the point we have utf8-encoded (`passutf8 = UTF8.encode password`) password (received as a list of chars from `haskeline`'s `getPassword`)

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/SDAO-)
## Related issue(s)
[SDAO-53](https://issues.serokell.io/issue/SDAO-53)
