### PR TITLE
[SDAO-40] Add multi epoch production test

### DIFF
--- a/stkr-token/package.yaml
+++ b/stkr-token/package.yaml
@@ -113,9 +113,12 @@ tests:
       - morley-prelude
       - lorentz-contracts
       - microlens
+      - microlens-th
       - QuickCheck
       - quickcheck-arbitrary-adt
+      - random
       - tasty
       - tasty-hspec
       - time
+      - universum
       - vinyl

--- a/stkr-token/package.yaml
+++ b/stkr-token/package.yaml
@@ -102,6 +102,7 @@ tests:
 
     dependencies:
       - base-noprelude >= 4.7 && < 5
+      - bytestring
       - containers
       - fmt
       - HUnit
@@ -113,6 +114,7 @@ tests:
       - lorentz-contracts
       - microlens
       - QuickCheck
+      - quickcheck-arbitrary-adt
       - tasty
       - tasty-hspec
       - time

--- a/stkr-token/test/Test/Lorentz/Contracts/STKR/Common.hs
+++ b/stkr-token/test/Test/Lorentz/Contracts/STKR/Common.hs
@@ -21,14 +21,20 @@ module Test.Lorentz.Contracts.STKR.Common
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
+import qualified Data.ByteString as BS
 import Data.Vinyl.Derived (Label)
 import Lens.Micro.Internal (At(..), Index, IxValue, Ixed(..))
 import Lorentz.Contracts.Client (multisignValue)
-import Lorentz.Contracts.Multisig (OrderDest(..), mkCallOrderWrap, TransferOrderWrapC)
+import Lorentz.Contracts.Multisig
+  (OrderDest(..), TransferOrderWrapC, mkCallOrderWrap)
 import Lorentz.Test
 import Lorentz.Value
 import Michelson.Test.Dummy (dummyNow)
+import Named (Name(..), NamedF)
+import Test.QuickCheck (Arbitrary(..), arbitrarySizedNatural)
+import Test.QuickCheck.Arbitrary.ADT (ToADTArbitrary, genericArbitrary)
 import Tezos.Crypto (PublicKey, SecretKey, detSecretKey, hashKey, toPublic)
+import Util.Named ((.!))
 
 import qualified Lorentz.Contracts.Multisig as Multisig
 import qualified Lorentz.Contracts.STKR as STKR
@@ -147,3 +153,20 @@ expectSuccess body _ _ _ = body
 
 failWhenNot :: Bool -> Text -> Either ValidationError ()
 failWhenNot cond message = when (not cond) (Left . CustomValidationError $ message)
+
+instance Arbitrary Natural where
+  arbitrary = arbitrarySizedNatural
+
+instance Arbitrary ByteString where
+  arbitrary = BS.pack <$> arbitrary
+
+instance Arbitrary a => Arbitrary (NamedF Identity a name) where
+  arbitrary = (Name @name .!) <$> arbitrary @a
+
+instance Arbitrary STKR.OpsTeamEntrypointParam where
+  arbitrary = genericArbitrary
+
+instance ToADTArbitrary STKR.OpsTeamEntrypointParam
+
+deriving newtype instance Arbitrary STKR.Sha256Hash
+deriving stock instance Show STKR.OpsTeamEntrypointParam

--- a/stkr-token/test/Test/Lorentz/Contracts/STKR/Governance/Gen.hs
+++ b/stkr-token/test/Test/Lorentz/Contracts/STKR/Governance/Gen.hs
@@ -1,0 +1,116 @@
+module Test.Lorentz.Contracts.STKR.Governance.Gen
+  ( EpochDesc
+  , num
+  , stages
+  , votes
+
+  , EpochVotes
+  , distribution
+  , winner
+
+
+  , genEpochDesc
+  , genProposal
+  , genProposals
+  ) where
+
+import Data.Time.Calendar (addDays, addGregorianMonthsClip, fromGregorian)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Lens.Micro (ix)
+import Lens.Micro.TH (makeLenses)
+import System.Random (Random)
+import Tezos.Core (Timestamp, timestampFromUTCTime)
+import Tezos.Crypto (SecretKey)
+
+import Test.QuickCheck (Gen, arbitrary, choose, vectorOf)
+
+import qualified Lorentz.Contracts.STKR as STKR
+
+import Test.Lorentz.Contracts.STKR.Common ()
+
+govEpochsStartingAt :: Integer -> Int -> [(Natural, [UTCTime])]
+govEpochsStartingAt year month =
+  startDayToEpoch <$> zip [0..] epochStartDays
+  where
+    epochStartDays = iterate (addGregorianMonthsClip 1) $
+      fromGregorian year month 1
+    dayToUTCTimeAtMidnight day = UTCTime day (secondsToDiffTime 0)
+    startDayToEpoch (epochNum, startDay) =
+      (epochNum,) $
+        dayToUTCTimeAtMidnight <$>
+          (flip addDays) startDay <$>
+          [0, 7, 14, 21]
+
+
+genProposal :: Gen STKR.Proposal
+genProposal = arbitrary
+
+genProposals :: (Int, Int) -> Gen [STKR.Proposal]
+genProposals len = choose len >>= flip vectorOf genProposal
+
+votesDistribution
+  :: Int
+  -> Int
+  -> Gen ([Int], Int)
+votesDistribution votesAvailible candidates = do
+  winner <- choose (0, candidates - 1)
+  winnerGap <- choose (1, votesAvailible - votesAvailible `div` 2)
+  let winnerVotes = votesAvailible `div` 2 + winnerGap
+  let votesLeft = votesAvailible - winnerVotes
+  votesWithoutWinner <- splitNum votesLeft (candidates - 1)
+  let votesWithWinner = insertAt winner winnerVotes votesWithoutWinner
+  pure (votesWithWinner, winner)
+  where
+    splitNum :: (Random a, Num a) => a -> Int -> Gen [a]
+    splitNum _ 0 = pure []
+    splitNum n size = do
+      chosen <- choose (0, n)
+      rest <- splitNum (n - chosen) (size - 1)
+      pure $ chosen : rest
+
+    insertAt :: Int -> a -> [a] -> [a]
+    insertAt i x xs =
+      let (ls, rs) = splitAt i xs
+      in ls ++ [x] ++ rs
+
+data EpochVotes = EpochVotes
+  { _distribution :: [(STKR.Proposal, [SecretKey])]
+  , _winner :: (STKR.Proposal, Int)
+  }
+
+makeLenses ''EpochVotes
+
+genEpochVotes :: [STKR.Proposal] -> [SecretKey] -> Gen EpochVotes
+genEpochVotes proposals councilSks = do
+  (epochVotes, winnerIndex) <- votesDistribution (length councilSks) (length proposals)
+  let winnerProposal =
+        fromMaybe (error "unreachable: winner is always in proposal list") $
+          proposals ^? ix winnerIndex
+  let assignSks votesNeeded (result, availibleSks) =
+        let (toBeAssigned, left) = splitAt votesNeeded availibleSks
+        in (toBeAssigned : result, left)
+  let votesAssignedToSks = fst $ foldr assignSks ([], councilSks) epochVotes
+  pure $ EpochVotes
+    { _distribution = zip proposals votesAssignedToSks
+    , _winner = (winnerProposal, winnerIndex)
+    }
+
+data EpochDesc = EpochDesc
+  { _num :: Natural
+  , _stages :: [Timestamp]
+  , _votes :: EpochVotes
+  }
+
+makeLenses ''EpochDesc
+
+genEpochDesc :: [SecretKey] -> Integer -> Int -> Int -> Gen [EpochDesc]
+genEpochDesc councilSks startYear startMonth n = do
+  let epochList = take n $ govEpochsStartingAt startYear startMonth
+  forM epochList $ \(epochNum, stageStarts) -> do
+    proposals <- genProposals (3, 5)
+    epochVotes <- genEpochVotes proposals councilSks
+    pure $ EpochDesc
+      { _num = epochNum
+      , _stages = timestampFromUTCTime <$> stageStarts
+      , _votes = epochVotes
+      }

--- a/stkr-token/test/Test/Lorentz/Contracts/STKR/Governance/ProposalLifecycle.hs
+++ b/stkr-token/test/Test/Lorentz/Contracts/STKR/Governance/ProposalLifecycle.hs
@@ -1,0 +1,208 @@
+module Test.Lorentz.Contracts.STKR.Governance.ProposalLifecycle
+  ( spec_ProposalLifecycle
+  ) where
+
+import Prelude
+
+import qualified Data.Map as Map
+import Lens.Micro (ix)
+import qualified Lorentz as L
+import Lorentz.Test
+import Named (arg)
+import Test.Hspec (Expectation, Spec, it)
+import Test.QuickCheck (generate)
+import Tezos.Core (Timestamp, timestampPlusSeconds)
+import Tezos.Crypto
+  (KeyHash, PublicKey, SecretKey, blake2b, hashKey, sign, toPublic)
+import Universum.Unsafe ((!!))
+import Util.Named ((:!), (.!))
+
+import qualified Lorentz.Contracts.Multisig as Msig
+import qualified Lorentz.Contracts.STKR as STKR
+
+import Test.Lorentz.Contracts.STKR.Common
+  (OriginateParams(..), callWithMultisig, failWhenNot, newKeypair,
+  originateWithTC)
+import Test.Lorentz.Contracts.STKR.Governance.Gen
+  (EpochDesc, distribution, genEpochDesc, num, stages, votes, winner)
+
+makeTestInput :: [SecretKey] -> IO [EpochDesc]
+makeTestInput sks = generate $
+  genEpochDesc sks 2020 1 100
+
+
+integrationalForEpochsSeq :: [SecretKey] -> (EpochDesc -> IntegrationalScenario) -> Expectation
+integrationalForEpochsSeq sks expectation = do
+  testInput <- makeTestInput sks
+  forM_  testInput $ \input ->
+      (integrationalTestExpectation . expectation $ input)
+
+integrationalForEpochsWithNext :: [SecretKey] -> ((EpochDesc, EpochDesc) -> IntegrationalScenario) -> Expectation
+integrationalForEpochsWithNext sks expectation = do
+  testInput <- makeTestInput sks
+  forM_  (zip testInput (drop 1 testInput)) $ \input ->
+      (integrationalTestExpectation . expectation $ input)
+
+
+originateWithProdTC
+  :: [PublicKey]
+  -> [PublicKey]
+  -> IntegrationalScenarioM
+    ( L.ContractRef Msig.Parameter
+    , L.ContractRef STKR.Parameter
+    )
+originateWithProdTC teamPks councilPks =
+  originateWithTC STKR.ProdTC { _startYear = 2020 } $
+    OriginateParams
+      { opTeamKeys = teamPks
+      , opCouncilKeys = councilPks
+      , opInitailLedger = mempty
+      }
+
+-- Hack to evaluate scenario part with given `now`
+-- because actual interpretation happens on validation step.
+-- This validation ensures than scenario part is evaluated with
+-- correct `now`.
+-- TODO: investigate into https://issues.serokell.io/issue/TM-218
+-- and updgrade morley dependency version as this would likely fix this issue
+setStage :: EpochDesc -> Natural -> IntegrationalScenarioM ()
+setStage epochDesc stage =
+  validate (Right expectAnySuccess) >> setNow (getStageTs epochDesc stage)
+
+getStageTs :: EpochDesc -> Natural -> Timestamp
+getStageTs desc i =
+  fromMaybe (error $ "failed to get stage " <> show i) $
+    desc ^? stages . ix (fromInteger $ toInteger i)
+
+voteForProposal
+  :: L.ContractRef STKR.Parameter
+  -> SecretKey
+  -> Natural
+  -> STKR.Proposal
+  -> Natural
+  -> IntegrationalScenarioM ()
+voteForProposal stkr voteSk proposalId proposal stageCounter = do
+  let votePk = toPublic voteSk
+  let bytesToSign = L.lPackValue $
+        STKR.CouncilDataToSign
+          { cdProposalHash = STKR.Blake2BHash . blake2b . L.lPackValue $ proposal
+          , cdContractAddr = L.fromContractAddr stkr
+          , cdStageCounter = stageCounter
+          }
+  lCall stkr
+    . STKR.PublicEntrypoint
+    . STKR.VoteForProposal $
+    ( #proposalId .! proposalId
+    , #votePk .! votePk
+    , #voteSig .! sign voteSk bytesToSign
+    )
+
+spec_ProposalLifecycle :: Spec
+spec_ProposalLifecycle = do
+  let (sk1, _) = newKeypair "1"
+  let (sk2, _) = newKeypair "2"
+  let (sk3, _) = newKeypair "3"
+  let (sk4, _) = newKeypair "4"
+  let (sk5, _) = newKeypair "5"
+  let teamSks = [sk1, sk2, sk3, sk4, sk5]
+  let teamPks = toPublic <$> teamSks
+
+  it "proposal submitted on boundary of stage 0 and 1 is rejected" $
+    integrationalForEpochsSeq teamSks $ \epoch -> do
+
+      (msig, stkr) <- originateWithProdTC teamPks []
+
+      setStage epoch 1
+      callWithMultisig msig 1 teamSks stkr . STKR.NewProposal $ epoch^.votes.winner._1
+      validate . Left $
+        lExpectCustomError #wrongStage (#stageCounter .! (epoch^.num * 4 + 1))
+
+  it "proposal submitted in the middle of stages 1, 2, 3 is rejected" $
+    integrationalForEpochsSeq teamSks $ \epoch -> do
+      (msig, stkr) <- originateWithProdTC teamPks []
+      branchout $ [1..3] <&> (\testingAgainstStage ->
+        ("for stage " <> show testingAgainstStage) ?- do
+          setNow $
+            let stageStart = getStageTs epoch testingAgainstStage
+                secondsInDay = 60 * 60 * 24
+            in timestampPlusSeconds stageStart $ 3 * secondsInDay
+          callWithMultisig msig 1 teamSks stkr . STKR.NewProposal $ epoch^.votes.winner._1
+          validate . Left $
+            lExpectCustomError #wrongStage $
+              #stageCounter .! (epoch^.num * 4 + testingAgainstStage))
+
+  it "if none of proposals received majority the policy doesn't change" $ do
+    let councilKeys = [sk1, sk2, sk3, sk4]
+    integrationalForEpochsWithNext councilKeys $ \(curEpoch, nextEpoch) -> do
+      let props = fst <$> curEpoch^.votes.distribution
+      if length props < 2
+      then validate . Right $ expectAnySuccess
+      else do
+        (msig, stkr) <- originateWithProdTC teamPks $ toPublic <$> councilKeys
+        setStage curEpoch 0
+        forM_ (zip [1..] props) $ \(i, prop) ->
+          callWithMultisig msig i teamSks stkr $ STKR.NewProposal prop
+
+        setStage curEpoch 2
+        forM_ [sk1, sk2] $ \sk ->
+          voteForProposal stkr sk 0 (reverse props !! 0) (curEpoch^.num * 4 + 2)
+        forM_ [sk3, sk4] $ \sk ->
+          voteForProposal stkr sk 1 (reverse props !! 1) (curEpoch^.num * 4 + 2)
+
+        setStage nextEpoch 0
+        callWithMultisig msig (toEnum $ length props + 1) teamSks stkr $ STKR.NewProposal (nextEpoch^.votes.winner._1)
+
+        validate . Right . lExpectStorageUpdate stkr $ \storage ->
+          failWhenNot (#urls Map.empty == STKR.policy storage) "Not equal"
+
+
+  it "poposal successfully submitted in epoch 0" $
+    integrationalForEpochsWithNext teamSks $ \(curEpoch, nextEpoch) -> do
+      let props = fst <$> curEpoch^.votes.distribution
+      (msig, stkr) <- originateWithProdTC teamPks teamPks
+      setStage curEpoch 0
+      forM_ (zip [1..] props) $ \(i, prop) ->
+        callWithMultisig msig i teamSks stkr $ STKR.NewProposal prop
+
+
+      branchout $
+        [ "proposals in storage are correct" ?- do
+            validate . Right . lExpectStorageUpdate stkr $ \storage -> do
+              failWhenNot (reverse props == (arg #proposal . fst <$> STKR.proposals storage)) $
+                "Submitted props: " <> show props <> "props in storage: " <> show (STKR.proposals storage)
+        , "policy changes after successful vote" ?- do
+            setStage curEpoch 2
+            let withPropId =
+                  zip
+                  (reverse ([0..(toEnum $ length props - 1)] :: [Natural]))
+                  (curEpoch^.votes.distribution)
+            forM_ withPropId $
+              \(proposalId, (proposal, voteSks)) ->
+                forM_ voteSks $ \voteSk -> do
+                  voteForProposal stkr voteSk proposalId proposal (curEpoch^.num * 4 + 2)
+
+            let sksToProposals :: Map KeyHash ("proposalId" :! Natural)
+                sksToProposals =
+                  withPropId
+                  & fmap (second $ fmap (hashKey . toPublic) . snd)
+                  & concatMap (\(propId, votesKeyHashes) -> (,propId) <$> votesKeyHashes)
+                  & fmap (second $ #proposalId)
+                  & Map.fromList
+
+            validate . Right . lExpectStorageUpdate stkr $ \storage -> do
+              failWhenNot (STKR.votes storage == sksToProposals) $ "Votes distributed incorrectly"
+
+            setStage nextEpoch 0
+            callWithMultisig msig (toEnum @Natural $ length props + 1) teamSks stkr . STKR.NewProposal $ nextEpoch^.votes.winner._1
+
+            validate . Right . lExpectStorageUpdate stkr $ \storage ->
+              failWhenNot (STKR.policy storage == (arg #newPolicy $ curEpoch^.votes.winner._1._2)) "Policy set incorrectly"
+
+        ]
+        ++ ([0, 1, 3] <&> (\stage -> ("vote call fails during stage " <> show stage) ?- do
+            let stageFromStart = curEpoch^.num * 4 + stage
+            setStage curEpoch stage
+            voteForProposal stkr sk1 0 (curEpoch^.votes.winner._1) stageFromStart
+            validate . Left $
+              lExpectCustomError #wrongStage (#stageCounter stageFromStart)
+        ))

--- a/stkr-token/test/Test/Lorentz/Contracts/STKR/TestCommon.hs
+++ b/stkr-token/test/Test/Lorentz/Contracts/STKR/TestCommon.hs
@@ -8,18 +8,17 @@ module Test.Lorentz.Contracts.STKR.TestCommon
   , spec_calcWinner
   ) where
 
-import qualified Data.Set as Set
-import qualified Data.Map as M
 import Data.Functor.Identity (Identity(..))
+import qualified Data.Map as M
+import qualified Data.Set as Set
 import Lens.Micro (ix)
 
 import Test.Hspec (Spec, it)
-import Test.HUnit ((@?=), (@?), assertFailure)
 import qualified Test.Hspec.QuickCheck as HQ
-import Test.QuickCheck (Arbitrary(..), Gen)
+import Test.HUnit (assertFailure, (@?), (@?=))
 
+import Tezos.Core (Timestamp(..), parseTimestamp, timestampToSeconds)
 import Tezos.Crypto (hashKey)
-import Tezos.Core (Timestamp (..), timestampToSeconds, parseTimestamp)
 
 import qualified Data.Time.Calendar as C
 import qualified Data.Time.Clock as C
@@ -28,13 +27,13 @@ import qualified Data.Time.Clock.POSIX as C
 import Michelson.Interpret (ContractEnv(..))
 import Michelson.Text (MText, mkMTextUnsafe)
 
-import Lorentz (KeyHash, (:!), Rec (..))
+import Lorentz ((:!), KeyHash, Rec(..))
 import qualified Lorentz as L
 import Lorentz.Test
 
-import Lorentz.Contracts.STKR.Storage
 import Lorentz.Contracts.STKR.Governance
 import Lorentz.Contracts.STKR.Misc
+import Lorentz.Contracts.STKR.Storage
 
 import Test.Lorentz.Contracts.STKR.Common (newKeypair)
 
@@ -163,11 +162,6 @@ spec_checkPkCanVote = do
       let initStack = (Identity pk :& Identity testStorage :& RNil)
       resStack <- L.interpretLorentzInstr dummyContractEnv (checkPkCanVote @'[]) initStack
       case resStack of RNil -> return True
-
-instance Arbitrary Natural where
-  arbitrary =
-    (\i -> fromInteger $ if i <= 0 then 1-i else i)
-    <$> (arbitrary :: Gen Integer)
 
 spec_splitCounter :: Spec
 spec_splitCounter =


### PR DESCRIPTION
## Related issue(s)
https://issues.serokell.io/issue/SDAO-40
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
