### PR TITLE
[SDAO-87] Add ledger support for signing

### DIFF
--- a/stkr-token/package.yaml
+++ b/stkr-token/package.yaml
@@ -44,6 +44,7 @@ library:
     - time
     - yaml
     - vinyl
+    - hex-text
 
   when:
     - condition: os(windows)
@@ -69,6 +70,8 @@ executables:
       - optparse-applicative
       - turtle
       - text
+      - hex-text
+
     ghc-options:
       - -threaded # IMPORTANT!
 

--- a/stkr-token/src/Lorentz/Contracts/Client.hs
+++ b/stkr-token/src/Lorentz/Contracts/Client.hs
@@ -23,8 +23,8 @@ module Lorentz.Contracts.Client
 import Prelude
 
 import Fmt (Buildable(..), Builder, mapF)
-import Named (arg)
 import Lens.Micro (ix)
+import Named (arg)
 
 import Lorentz.Constraints (NicePackedValue)
 import Lorentz.Pack (lPackValue)


### PR DESCRIPTION
## Description

Problem: StakerDAO operations team and councils need a secure way of signing
multisig packages and votes.

Solution: add support for signing values through `tezos-client` which handles
working with ledger for us.

*IMPORTANT*
As for now original `tezos-client` does not support signing arbitrary bytestring for this to work you would need special patched version of `tezos-client`:
* Patched for babylonnet https://gitlab.com/serokell/morley/tezos/tree/rvem/babylonnet-client-patched
* Patched for mainnet https://gitlab.com/serokell/morley/tezos/tree/rvem/mainnet-client-patched

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/SDAO-)
## Related issue(s)
https://issues.serokell.io/issue/SDAO-87
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
